### PR TITLE
Allow to specify custom cron format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Note: This LWRP does not function on Solaris platforms because they do not suppo
 #### Attributes
 * `minute`, `hour`, `day`, `month`, `weekday` - schedule your cron job. These correspond exactly to their equivalents in the crontab file. All default to "*".
 * `predefined_value` - schedule your cron job with one of the special predefined value instead of * * * * * pattern. This correspond to @reboot, @yearly, @annually, @monthly, @weekly, @daily, @midnight or @hourly.
+* `custom` - schedule your cron job with raw * * * * * pattern. This correspond to @reboot, @yearly, @annually, @monthly, @weekly, @daily, @midnight or @hourly.
 * `command` - the command to run. Required.
 * `user` - the user to run as. Defaults to "root".
 * `mailto`, `path`, `home`, `shell` - set the corresponding environment variables in the cron.d file. No default.

--- a/providers/d.rb
+++ b/providers/d.rb
@@ -40,6 +40,7 @@ action :create do
     variables(
                 :name => new_resource.name,
                 :predefined_value => new_resource.predefined_value,
+                :custom => new_resource.custom,
                 :minute => new_resource.minute,
                 :hour => new_resource.hour,
                 :day => new_resource.day,

--- a/resources/d.rb
+++ b/resources/d.rb
@@ -23,6 +23,7 @@ attribute :name, :kind_of => String, :name_attribute => true
 attribute :cookbook, :kind_of => String, :default => 'cron'
 
 attribute :predefined_value, :kind_of => [String], :default => nil, :callbacks => { 'should be a valid predefined value' => lambda { |spec| validate_predefined_value(spec) } }
+attribute :custom, :kind_of => [String], :default => nil, :callbacks => { 'should be a valid cron format' => lambda { |spec| validate_custom_value(spec) } }
 attribute :minute, :kind_of => [Integer, String], :default => '*', :callbacks => { 'should be a valid minute spec' => lambda { |spec| validate_numeric(spec, 0, 59) } }
 attribute :hour, :kind_of => [Integer, String], :default => '*', :callbacks => { 'should be a valid hour spec' => lambda { |spec| validate_numeric(spec, 0, 23) } }
 attribute :day, :kind_of => [Integer, String], :default => '*', :callbacks => { 'should be a valid day spec' => lambda { |spec| validate_numeric(spec, 1, 31) } }
@@ -52,6 +53,14 @@ def self.validate_predefined_value(spec)
   else
     return false
   end
+end
+
+def self.validate_custom_value(spec)
+  return true if spec.nil?
+
+  # pattern: * * * * *
+  values = spec.split(/\s+/)
+  return values.size == 5
 end
 
 def self.validate_numeric(spec, min, max)

--- a/spec/unit/cron_test/default_spec.rb
+++ b/spec/unit/cron_test/default_spec.rb
@@ -53,6 +53,14 @@ describe 'cron_test::default' do
       )
   end
 
+  it 'creates cron_d[custom_check]' do
+    expect(chef_run).to create_cron_d('custom_check').with(
+      :custom => '*/2 2 1 20 *',
+      :command => '/bin/true',
+      :user => 'appuser'
+      )
+  end
+
   it 'creates cron_d[nil_value_check]' do
     expect(chef_run).to create_cron_d('nil_value_check').with(
       :predefined_value => nil,

--- a/templates/default/cron.d.erb
+++ b/templates/default/cron.d.erb
@@ -20,6 +20,8 @@ HOME=<%= @home %>
 <% end -%>
 <% if @predefined_value -%>
 <%= @predefined_value %> <%= @user %> <%= @command %>
+<% elsif @custom -%>
+<%= @custom %> <%= @user %> <%= @command %>
 <% else -%>
 <%= @minute %> <%= @hour %> <%= @day %> <%= @month %> <%= @weekday %> <%= @user %> <%= @command %>
 <% end -%>

--- a/test/fixtures/cookbooks/cron_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cron_test/recipes/default.rb
@@ -62,6 +62,13 @@ cron_d 'predefined_value_check' do
   action :create
 end
 
+cron_d 'custom_check' do
+  custom '*/2 2 1 20 *'
+  command '/bin/true'
+  user 'appuser'
+  action :create
+end
+
 cron_d 'nil_value_check' do
   predefined_value nil
   command '/bin/true'


### PR DESCRIPTION
Sometime I need to specify some format example every 10 minutes: `*/10 * * * * `
So added param `custom` to use raw cron format:

```ruby
cron_d 'custom_check' do
  custom '*/2 2 1 20 *'
  command '/bin/true'
  user 'appuser'
  action :create
end
```

would generate `/etc/cron.d/custom_check`
```cron
*/2 2 1 20 * appuser /bin/true
```
