### PR TITLE
adding action create_if_missing

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -3,6 +3,10 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:cron_d, :create, resource_name)
   end
 
+  def create_if_missing_cron_d(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:cron_d, :create_if_missing, resource_name)
+  end
+
   def delete_cron_d(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:cron_d, :delete, resource_name)
   end

--- a/providers/d.rb
+++ b/providers/d.rb
@@ -23,17 +23,20 @@
 # FIXME: replace when Chef 12 is released.
 
 action :delete do
-  f = file "/etc/cron.d/#{new_resource.name}" do
-    action :delete
-    notifies :create, 'template[/etc/crontab]', :delayed if node['cron']['emulate_cron.d']
-  end
-  new_resource.updated_by_last_action(f.updated_by_last_action?)
+  r = create_template
+  r.action :delete
+  new_resource.updated_by_last_action(r.updated_by_last_action?)
 end
 
 action :create do
   # We should be able to switch emulate_cron.d on for Solaris, but I don't have a Solaris box to verify
   fail 'Solaris does not support cron jobs in /etc/cron.d' if node['platform_family'] == 'solaris2'
-  t = template "/etc/cron.d/#{new_resource.name}" do
+  r = create_template
+  new_resource.updated_by_last_action(r.updated_by_last_action?)
+end
+
+def create_template
+  template "/etc/cron.d/#{new_resource.name}" do
     cookbook new_resource.cookbook
     source 'cron.d.erb'
     mode new_resource.mode
@@ -57,5 +60,4 @@ action :create do
     action :create
     notifies :create, 'template[/etc/crontab]', :delayed if node['cron']['emulate_cron.d']
   end
-  new_resource.updated_by_last_action(t.updated_by_last_action?)
 end

--- a/providers/d.rb
+++ b/providers/d.rb
@@ -35,6 +35,12 @@ action :create do
   new_resource.updated_by_last_action(r.updated_by_last_action?)
 end
 
+action :create_if_missing do
+  r = create_template
+  r.action :create_if_missing
+  new_resource.updated_by_last_action(r.updated_by_last_action?)
+end
+
 def create_template
   template "/etc/cron.d/#{new_resource.name}" do
     cookbook new_resource.cookbook

--- a/resources/d.rb
+++ b/resources/d.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-actions :create, :delete
+actions :create, :create_if_missing, :delete
 default_action :create
 
 attribute :name, kind_of: String, name_attribute: true

--- a/spec/unit/cron_test/default_spec.rb
+++ b/spec/unit/cron_test/default_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 describe 'cron_test::default' do
-  let(:chef_run) do
-    ChefSpec::ServerRunner.new.converge('cron_test::default')
+  cached(:chef_run) { ChefSpec::SoloRunner.converge('cron_test::default') }
+
+  it 'enables and starts service[cron]' do
+    expect(chef_run).to enable_service('cron')
+    expect(chef_run).to start_service('cron')
   end
 
   it 'creates cron_d[bizarrely-scheduled-usage-report]' do
@@ -66,6 +69,10 @@ describe 'cron_test::default' do
       command: '/bin/true',
       user: 'appuser'
     )
+  end
+
+  it 'creates file[/etc/cron.d/delete_cron]' do
+    expect(chef_run).to create_file('/etc/cron.d/delete_cron')
   end
 
   it 'deletes cron_d[delete_cron]' do

--- a/spec/unit/cron_test/default_spec.rb
+++ b/spec/unit/cron_test/default_spec.rb
@@ -61,8 +61,8 @@ describe 'cron_test::default' do
     )
   end
 
-  it 'creates cron_d[no_value_check]' do
-    expect(chef_run).to create_cron_d('no_value_check').with(
+  it 'creates if missing cron_d[no_value_check]' do
+    expect(chef_run).to create_if_missing_cron_d('no_value_check').with(
       command: '/bin/true',
       user: 'appuser'
     )

--- a/spec/unit/cron_test/default_spec.rb
+++ b/spec/unit/cron_test/default_spec.rb
@@ -67,4 +67,11 @@ describe 'cron_test::default' do
       user: 'appuser'
     )
   end
+
+  it 'deletes cron_d[delete_cron]' do
+    expect(chef_run).to delete_cron_d('delete_cron').with(
+      command: '/bin/true',
+      user: 'appuser'
+    )
+  end
 end

--- a/test/fixtures/cookbooks/cron_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cron_test/recipes/default.rb
@@ -74,3 +74,13 @@ cron_d 'no_value_check' do
   user 'appuser'
   action :create
 end
+
+file '/etc/cron.d/delete_cron' do
+  content '* * * * * appuser /bin/true'
+end
+
+cron_d 'delete_cron' do
+  command '/bin/true'
+  user 'appuser'
+  action :delete
+end

--- a/test/fixtures/cookbooks/cron_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cron_test/recipes/default.rb
@@ -63,7 +63,6 @@ cron_d 'predefined_value_check' do
 end
 
 cron_d 'nil_value_check' do
-  predefined_value nil
   command '/bin/true'
   user 'appuser'
   action :create
@@ -72,7 +71,7 @@ end
 cron_d 'no_value_check' do
   command '/bin/true'
   user 'appuser'
-  action :create
+  action :create_if_missing
 end
 
 file '/etc/cron.d/delete_cron' do

--- a/test/integration/default/serverspec/localhost/cron_spec.rb
+++ b/test/integration/default/serverspec/localhost/cron_spec.rb
@@ -33,4 +33,7 @@ else
   describe file('/etc/cron.d/nil_value_check') do
     its(:content) { should match /\* \* \* \* \* appuser \/bin\/true/ }
   end
+  describe file('/etc/cron.d/delete_cron') do
+    it { should_not exist }
+  end
 end


### PR DESCRIPTION
need the ability to create crons in dev, but not manage them afterwards so developers can make changes without fear or chef overwriting.

also updates spec to have full coverage along with testing  `action :delete`