### PR TITLE
Convert to inline resources and test create_if_missing

### DIFF
--- a/spec/unit/cron_test/default_spec.rb
+++ b/spec/unit/cron_test/default_spec.rb
@@ -76,9 +76,6 @@ describe 'cron_test::default' do
   end
 
   it 'deletes cron_d[delete_cron]' do
-    expect(chef_run).to delete_cron_d('delete_cron').with(
-      command: '/bin/true',
-      user: 'appuser'
-    )
+    expect(chef_run).to delete_cron_d('delete_cron')
   end
 end

--- a/test/fixtures/cookbooks/cron_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cron_test/recipes/default.rb
@@ -74,12 +74,19 @@ cron_d 'no_value_check' do
   action :create_if_missing
 end
 
+cron_d 'test-weekday-usage-report' do
+  minute '1'
+  hour '1'
+  weekday '1'
+  command '/this/should/never/run'
+  user 'appuser'
+  action :create_if_missing
+end
+
 file '/etc/cron.d/delete_cron' do
   content '* * * * * appuser /bin/true'
 end
 
 cron_d 'delete_cron' do
-  command '/bin/true'
-  user 'appuser'
   action :delete
 end

--- a/test/integration/default/serverspec/localhost/cron_spec.rb
+++ b/test/integration/default/serverspec/localhost/cron_spec.rb
@@ -30,6 +30,10 @@ if os[:family] == 'freebsd'
     its(:content) { should match /\* \* \* \* \* appuser \/bin\/true/ }
   end
 else
+  # make sure the :create_if_missing didn't overwrite the :create
+  describe file('/etc/cron.d/test-weekday-usage-report') do
+    its(:content) { should match /\/srv\/app\/scripts\/generate_report/ }
+  end
   describe file('/etc/cron.d/nil_value_check') do
     its(:content) { should match /\* \* \* \* \* appuser \/bin\/true/ }
   end


### PR DESCRIPTION
Inline resources greatly simplify the notification issues. This also
fixes requiring a command when you delete a cron entry, which was a
regression in 1.7.1. I've added a serverspec to ensure we're handling
create_if_missing correctly by first creating a cron entry, then
creating it again with create_if_missing.  We can expect to find the
content of the first creation only.