### PR TITLE
strip dots from cron filenames (or else will not run)

### DIFF
--- a/providers/d.rb
+++ b/providers/d.rb
@@ -19,8 +19,10 @@
 
 use_inline_resources
 
+sanitized_filename = new_resource.name.gsub('.', '-')
+
 action :delete do
-  file "/etc/cron.d/#{new_resource.name}" do
+  file "/etc/cron.d/#{sanitized_filename}" do
     action :delete
     notifies :create, 'template[/etc/crontab]', :delayed if node['cron']['emulate_cron.d']
   end
@@ -37,12 +39,12 @@ action :create_if_missing do
 end
 
 def create_template(create_action)
-  template "/etc/cron.d/#{new_resource.name}" do
+  template "/etc/cron.d/#{sanitized_filename}" do
     cookbook new_resource.cookbook
     source 'cron.d.erb'
     mode new_resource.mode
     variables(
-      name: new_resource.name,
+      name: sanitized_filename,
       predefined_value: new_resource.predefined_value,
       minute: new_resource.minute,
       hour: new_resource.hour,

--- a/providers/d.rb
+++ b/providers/d.rb
@@ -19,7 +19,7 @@
 
 use_inline_resources
 
-sanitized_filename = new_resource.name.gsub('.', '-')
+sanitized_filename = new_resource.name.tr('.', '-')
 
 action :delete do
   file "/etc/cron.d/#{sanitized_filename}" do


### PR DESCRIPTION
Confirmed on ubuntu 14.04

EDIT: Sorry, should have more context. A file like `/etc/cron.d/run-it` will work fine, but `/etc/cron.d/example.com-run-it` will not. I would say that this is unexpected behaviour.

I spent a few hours sorting it out, so I'd like to get the change into this cookbook to same others the grief.

We could either convert them to hyphens or strip them outright. I air on the side of hyphernating :)