### PR TITLE
Fix for CHEF_3694

### DIFF
--- a/test/fixtures/cookbooks/cron_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cron_test/recipes/default.rb
@@ -80,7 +80,8 @@ cron_d 'job.with.periods' do
   action :create_if_missing
 end
 
-cron_d 'test-weekday-usage-report' do
+cron_d 'test-weekday-usage-report2' do
+  name 'test-weekday-usage-report'
   minute '1'
   hour '1'
   weekday '1'


### PR DESCRIPTION
WARN: Cloning resource attributes for cron_d[test-weekday-usage-report] from prior resource (CHEF-3694)
Previous cron_d[test-weekday-usage-report]: /tmp/kitchen/cookbooks/cron_test/recipes/default.rb:40:in `from_file'
WARN: Current  cron_d[test-weekday-usage-report]: /tmp/kitchen/cookbooks/cron_test/recipes/default.rb:83:in `from_file'