### PR TITLE
always define service_name attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,8 @@ default['cron']['service_name'] = case node['platform_family']
                                     'cronie'
                                   when 'gentoo'
                                     'vixie-cron'
+                                  else
+                                    'cron'
                                   end
 
 # I think we can add Solaris to this list, but I don't have a Solaris box to test on.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,7 @@ node['cron']['package_name'].each do |pkg|
 end
 
 service 'cron' do
-  service_name node['cron']['service_name'] unless node['cron']['service_name'].nil?
+  service_name node['cron']['service_name']
   action [:enable, :start]
 end
 


### PR DESCRIPTION
### Description

Improve consistency when defining attributes. I was trying to look what the value of `service_name` is defined for `debian` platform and could not find it (the recipe relied on default `name` inheritance)
### Issues Resolved

This ensures attribute value is always defined on all platforms and that the attribute value could be used in other recipes.
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
