### PR TITLE
make env variables safe

### DIFF
--- a/resources/d.rb
+++ b/resources/d.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+require 'shellwords'
+
 property :name, String, name_property: true
 property :cookbook, String, default: 'cron'
 

--- a/templates/cron.d.erb
+++ b/templates/cron.d.erb
@@ -12,7 +12,7 @@ SHELL=<%= @shell %>
 HOME=<%= @home %>
 <% end -%>
 <% @environment.each do |key, val| -%>
-<%= key %>=<%= val %>
+<%= key %>=<%= val.to_s.shellescape %>
 <% end -%>
 
 <% if @comment -%>


### PR DESCRIPTION
fixes https://github.com/chef-cookbooks/cron/issues/86

before:
```
FOO=true
FOO=1
FOO=this looks broken
FOO=how
about
some
newlines
```

after:
```
FOO=true
FOO=1
FOO=this\ looks\ fine
FOO=how'\n'about'\n'some'\n'newlines
```

@tas50 