### PR TITLE
Fix the namespacing and cookstyle violations in validators (Fixes #80)

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,66 @@
+class Cron
+  class Helpers
+    def self.validate_predefined_value(spec)
+      # Several special predefined values can substitute in the cron expression
+      spec.nil? ||
+        %w(
+          @reboot
+          @yearly
+          @annually
+          @monthly
+          @weekly
+          @daily
+          @midnight
+          @hourly
+        ).include?(spec.downcase)
+    end
+
+    def self.validate_numeric(spec, min, max)
+      return true if spec == '*'
+      #  binding.pry
+      if spec.is_a? Integer
+        return false unless spec >= min && spec <= max
+        return true
+      end
+
+      # Lists of invidual values, ranges, and step values all share the validity range for type
+      spec.split(%r{\/|-|,}).each do |x|
+        next if x == '*'
+        return false unless x =~ /^\d+$/
+        x = x.to_i
+        return false unless x >= min && x <= max
+      end
+      true
+    end
+
+    def self.validate_month(spec)
+      return true if spec == '*'
+      if spec.class == Integer
+        validate_numeric(spec, 1, 12)
+      elsif spec.class == String
+        return true if spec == '*'
+        # Named abbreviations are permitted but not as part of a range or with stepping
+        return true if %w(jan feb mar apr may jun jul aug sep oct nov dec).include? spec.downcase
+        # 1-12 are legal for months
+        validate_numeric(spec, 1, 12)
+      else
+        false
+      end
+    end
+
+    def self.validate_dow(spec)
+      return true if spec == '*'
+      if spec.class == Integer
+        validate_numeric(spec, 0, 7)
+      elsif spec.class == String
+        return true if spec == '*'
+        # Named abbreviations are permitted but not as part of a range or with stepping
+        return true if %w(sun mon tue wed thu fri sat).include? spec.downcase
+        # 0-7 are legal for days of week
+        validate_numeric(spec, 0, 7)
+      else
+        false
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,3 +15,5 @@ end
 source_url 'https://github.com/chef-cookbooks/cron'
 issues_url 'https://github.com/chef-cookbooks/cron/issues'
 chef_version '>= 12.5' if respond_to?(:chef_version)
+
+depends 'compat_resource'


### PR DESCRIPTION
### Description

Moves helpers to their own library and addresses them from the root namespace (since callbacks appear to be in an isolated namespace now that we're using custom resources.

Also, I added a dependency for the [compat_resource cookbook](https://github.com/chef-cookbooks/compat_resource) so that the cookbook really is compatible with Chef 12.5 as claimed [in the metadata](https://github.com/chef-cookbooks/cron/blob/master/metadata.rb#L17).

### Issues Resolved

* Fixes #80: Default value "*" is invalid for property [...] of resource cron_d. In Chef 13 this will become an error

### Check List

- [✓] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [NA] New functionality includes testing.
- [NA] New functionality has been documented in the README if applicable
- [✓] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
