### PR TITLE
Fix handling of numeric weekdays (Fixes #74)

### DIFF
--- a/test/fixtures/cookbooks/cron_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/cron_test/recipes/default.rb
@@ -64,6 +64,15 @@ cron_d 'fixnum-job' do
   action :create
 end
 
+cron_d 'fixnum-weekdayjob' do
+  minute 0
+  hour 1
+  weekday 2
+  command '/bin/true'
+  user 'appuser'
+  action :create
+end
+
 cron_d 'predefined_value_check' do
   predefined_value '@midnight'
   command '/bin/true'


### PR DESCRIPTION
### Description

Match integers using duck typing instead of `is_a? Integer` which doesn't actually work.

### Issues Resolved

- #74: Support Weekdays
- #90: cron_d month option not accepting integer. (basically a duplicate of #74)

### Check List

- [✓] All tests pass.* See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [✓] New functionality includes testing.
- [NA] New functionality has been documented in the README if applicable
- [✓] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

*Tests pass once #92 is merged in ;-)