### PR TITLE
fix for chef-client 13 error Signed-off-by: Julia Child <juliachild@chef.io>

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 default['cron']['package_name'] = case node['platform_family']
                                   when 'debian'
                                     ['cron']
-                                  when 'rhel', 'fedora', 'suse'
+                                  when 'rhel', 'fedora', 'suse', 'amazon'
                                     node['platform_version'].to_f >= 6.0 ? ['cronie'] : ['vixie-cron']
                                   when 'solaris2'
                                     'core-os'
@@ -28,7 +28,7 @@ default['cron']['package_name'] = case node['platform_family']
                                   end
 
 default['cron']['service_name'] = case node['platform_family']
-                                  when 'rhel', 'fedora'
+                                  when 'rhel', 'fedora', 'amazon'
                                     'crond'
                                   else
                                     'cron'


### PR DESCRIPTION
### Description

chef-client 13 sets platform_family to amazon now instead of rhel. This PR fixes the attributes for amazon linux nodes.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
