### PR TITLE
chef-client 13 amazon linux fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 default['cron']['package_name'] = case node['platform_family']
                                   when 'debian'
                                     ['cron']
-                                  when 'rhel', 'fedora', 'suse'
+                                  when 'amazon', 'rhel', 'fedora', 'suse'
                                     node['platform_version'].to_f >= 6.0 ? ['cronie'] : ['vixie-cron']
                                   when 'solaris2'
                                     'core-os'
@@ -28,7 +28,7 @@ default['cron']['package_name'] = case node['platform_family']
                                   end
 
 default['cron']['service_name'] = case node['platform_family']
-                                  when 'rhel', 'fedora'
+                                  when 'amazon', 'rhel', 'fedora'
                                     'crond'
                                   else
                                     'cron'


### PR DESCRIPTION
Signed-off-by: Corey Hemminger <corey.hemminger@nativex.com>

### Description

fixes chef-client 13 compatibilty with amazon linux machines. Chef-client 13 now sets platform_family to amazon instead of rhel for amazon linux machines.

### Issues Resolved

#101 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
