### PR TITLE
define pld linux package and service name used for cron

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,12 +25,14 @@ default['cron']['package_name'] = case node['platform_family']
                                     node['platform_version'].to_i >= 12 ? ['cronie'] : ['cron']
                                   when 'solaris2'
                                     'core-os'
+                                  when 'pld'
+                                    'cronie'
                                   else
                                     []
                                   end
 
 default['cron']['service_name'] = case node['platform_family']
-                                  when 'amazon', 'rhel', 'fedora'
+                                  when 'amazon', 'rhel', 'fedora', 'pld'
                                     'crond'
                                   else
                                     'cron'


### PR DESCRIPTION
### Description

Define [PLD Linux](https://www.pld-linux.org/) package and service name used for cron.

This just makes cookbook work in PLD-Linux, does not mention it's officially supported, which is fine.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
