### PR TITLE
Finish implementing the random_delay property

### DIFF
--- a/resources/d.rb
+++ b/resources/d.rb
@@ -49,6 +49,7 @@ property :shell, [String, NilClass]
 property :comment, [String, NilClass]
 property :environment, Hash, default: {}
 property :mode, [String, Integer], default: '0600'
+property :random_delay, [Integer, NilClass]
 
 def after_created
   raise 'The cron_d resource requires Linux as it needs support for the cron.d directory functionality.' unless node['os'] == 'linux'
@@ -106,6 +107,7 @@ action_class do
         home: new_resource.home,
         shell: new_resource.shell,
         comment: new_resource.comment,
+        random_delay: new_resource.random_delay,
         environment: new_resource.environment
       )
       action create_action

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -102,6 +102,13 @@ cron_d 'job.with.periods' do
   action :create_if_missing
 end
 
+cron_d 'with_random_delay' do
+  command '/bin/true'
+  user 'appuser'
+  action :create_if_missing
+  random_delay 60
+end
+
 cron_d 'test-weekday-usage-report2' do
   name 'test-weekday-usage-report'
   minute '1'

--- a/test/integration/default/inspec/cron_spec.rb
+++ b/test/integration/default/inspec/cron_spec.rb
@@ -31,6 +31,9 @@ end
 describe file('/etc/cron.d/job-with-periods') do
   it { should exist }
 end
+describe file('/etc/cron.d/with_random_delay') do
+  its(:content) { should match(/RANDOM_DELAY=60/) }
+end
 
 # we created this in the test recipe and the provider should clean it up
 describe file('/etc/cron.d/job.with.periods') do


### PR DESCRIPTION
Signed-off-by: Mark Ryan <mark-from-usds@users.noreply.github.com>

### Description

This change finishes the functionality begun in [PR 103](https://github.com/chef-cookbooks/cron/pull/103), allowing a user to specify a random_delay property to a cron.d recipe. 

### Issues Resolved

#85 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
