### PR TITLE
Avoid deprecation warnings post Chef 14.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
     packages:
       - chef-workstation
 
-# Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"
 
 env:
@@ -24,6 +23,7 @@ env:
   - INSTANCE=default-centos-7 CHEF_VERSION=13
   - INSTANCE=default-debian-8 CHEF_VERSION=13
   - INSTANCE=default-debian-9 CHEF_VERSION=13
+  - INSTANCE=default-debian-10 CHEF_VERSION=13
   - INSTANCE=default-fedora-latest CHEF_VERSION=13
   - INSTANCE=default-ubuntu-1604 CHEF_VERSION=13
   - INSTANCE=default-ubuntu-1804 CHEF_VERSION=13
@@ -31,10 +31,23 @@ env:
   - INSTANCE=default-amazonlinux CHEF_VERSION=13
   - INSTANCE=default-amazonlinux-2 CHEF_VERSION=13
   - INSTANCE=manage-centos-7 CHEF_VERSION=13
+  - INSTANCE=default-centos-6 CHEF_VERSION=14
+  - INSTANCE=default-centos-7 CHEF_VERSION=14
+  - INSTANCE=default-debian-8 CHEF_VERSION=14
+  - INSTANCE=default-debian-9 CHEF_VERSION=14
+  - INSTANCE=default-debian-10 CHEF_VERSION=14
+  - INSTANCE=default-fedora-latest CHEF_VERSION=14
+  - INSTANCE=default-ubuntu-1604 CHEF_VERSION=14
+  - INSTANCE=default-ubuntu-1804 CHEF_VERSION=14
+  - INSTANCE=default-opensuse-leap CHEF_VERSION=14
+  - INSTANCE=default-amazonlinux CHEF_VERSION=14
+  - INSTANCE=default-amazonlinux-2 CHEF_VERSION=14
+  - INSTANCE=manage-centos-7 CHEF_VERSION=14
   - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7
   - INSTANCE=default-debian-8
   - INSTANCE=default-debian-9
+  - INSTANCE=default-debian-10
   - INSTANCE=default-fedora-latest
   - INSTANCE=default-ubuntu-1604
   - INSTANCE=default-ubuntu-1804
@@ -47,15 +60,13 @@ before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(chef shell-init bash)"
   - chef --version
-  - cookstyle --version
-  - foodcritic --version
 
 script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml CHEF_VERSION=${CHEF_VERSION} kitchen verify ${INSTANCE}
 
 matrix:
   include:
     - script:
-      - chef exec delivery local all
+      - delivery local all
       env:
         - UNIT_AND_LINT=1
         - CHEF_LICENSE=accept

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
-sudo: required
 
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-current-xenial
     packages:
-      - chefdk
+      - chef-workstation
 
 # Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"
+
+env:
+  - CHEF_LICENSE=accept
 
 branches:
   only:
@@ -54,4 +56,6 @@ matrix:
   include:
     - script:
       - chef exec delivery local all
-      env: UNIT_AND_LINT=1
+      env:
+        - UNIT_AND_LINT=1
+        - CHEF_LICENSE=accept

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # This gemfile provides additional gems for testing and releasing this cookbook
-# It is meant to be installed on top of ChefDK which provides the majority
+# It is meant to be installed on top of ChefDK / Chef Workstation which provide the majority
 # of the necessary gems for testing this cookbook
 #
 # Run 'chef exec bundle install' to install these dependencies

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,6 +2,7 @@ driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept-no-persist
 
 transport:
   name: dokken
@@ -34,6 +35,13 @@ platforms:
 - name: debian-9
   driver:
     image: dokken/debian-9
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: debian-10
+  driver:
+    image: dokken/debian-10
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,7 @@ driver:
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,14 +13,14 @@ platforms:
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
-  - name: amazonlinux-2 # requires insalling the virtualbox extension pack
+  - name: amazonlinux-2 # requires installing the virtualbox extension pack
     driver_config:
       box: stakahashi/amazonlinux2
   - name: centos-6
   - name: centos-7
-  - name: debian-8
   - name: debian-9
-  - name: fedora-28
+  - name: debian-10
+  - name: fedora-29
   - name: opensuse-leap-42
   - name: sles-11-sp2
     driver:

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,10 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs cron'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '6.2.1'
-
-recipe 'cron', 'Installs the cron package and starts the crond service.'
 
 %w(ubuntu debian fedora redhat centos scientific oracle amazon smartos omnios solaris2 freebsd zlinux opensuse suse opensuseleap).each do |os|
   supports os
@@ -14,4 +11,4 @@ end
 
 source_url 'https://github.com/chef-cookbooks/cron'
 issues_url 'https://github.com/chef-cookbooks/cron/issues'
-chef_version '>= 12.7' if respond_to?(:chef_version)
+chef_version '>= 12.7'

--- a/resources/access.rb
+++ b/resources/access.rb
@@ -6,7 +6,7 @@
 # Author:: Tim Smith <tsmith@chef.io>
 #
 # Copyright:: 2014-2018, Sander Botman
-# Copyright:: 2018, Chef Software, Inc.
+# Copyright:: 2018-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,9 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 14.4' if respond_to?(:chef_version_for_provides)
 resource_name :cron_access
-provides :cron_access
+
 provides :cron_manage # legacy name
 
 property :user, String, name_property: true

--- a/resources/d.rb
+++ b/resources/d.rb
@@ -2,7 +2,7 @@
 # Cookbook:: cron
 # Resource:: d
 #
-# Copyright:: 2008-2018, Chef Software, Inc.
+# Copyright:: 2008-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+chef_version_for_provides '< 14.4' if respond_to?(:chef_version_for_provides)
+resource_name :cron_d
 
 require 'shellwords'
 

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -144,7 +144,7 @@ cron_access 'tom' do
 end
 
 # legacy resource name
-cron_manage 'Bill breaks things. Take away cron' do
+cron_manage 'Bill breaks things. Take away cron' do # rubocop: disable ChefModernize/CronManageResource
   user 'bill'
   action :deny
 end


### PR DESCRIPTION
Don't load these resources on modern chef-client releases.

Signed-off-by: Tim Smith <tsmith@chef.io>